### PR TITLE
Problem: medium shiftleft scan findings (fix #127)

### DIFF
--- a/x/chainmain/client/cli/testnet.go
+++ b/x/chainmain/client/cli/testnet.go
@@ -527,7 +527,7 @@ func writeFile(name string, dir string, contents []byte) error {
 		return err
 	}
 
-	err = tmos.WriteFile(file, contents, 0644)
+	err = tmos.WriteFile(file, contents, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Solution: changed filemode to 644, remove `defer` for file close, add path validity checking