### PR TITLE
Problem (fix #202): no api to list/query/monitor module accounts

### DIFF
--- a/pystarport/poetry.lock
+++ b/pystarport/poetry.lock
@@ -13,6 +13,14 @@ tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six
 tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
+name = "bech32"
+version = "1.2.0"
+description = "Reference implementation for Bech32 and segwit addresses."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "certifi"
 version = "2020.6.20"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -263,6 +271,10 @@ content-hash = "40834016aaa9a05e2fb2f97c38ab322cf7916360e7e3192447aedd1bc3ccb75b
 attrs = [
     {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
     {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
+]
+bech32 = [
+    {file = "bech32-1.2.0-py3-none-any.whl", hash = "sha256:990dc8e5a5e4feabbdf55207b5315fdd9b73db40be294a19b3752cde9e79d981"},
+    {file = "bech32-1.2.0.tar.gz", hash = "sha256:7d6db8214603bd7871fcfa6c0826ef68b85b0abd90fa21c285a9c5e21d2bd899"},
 ]
 certifi = [
     {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},

--- a/pystarport/pyproject.toml
+++ b/pystarport/pyproject.toml
@@ -14,6 +14,7 @@ python-dateutil = "^2.8.1"
 durations = "^0.3.3"
 supervisor = "^4.2.1"
 docker = "^4.3.1"
+bech32 = "^1.2.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/pystarport/pystarport/utils.py
+++ b/pystarport/pystarport/utils.py
@@ -53,3 +53,11 @@ def build_cli_args(*args, **kwargs):
         args.append("--" + k.strip("_").replace("_", "-"))
         args.append(v)
     return list(map(str, args))
+
+
+def format_doc_string(**kwargs):
+    def decorator(target):
+        target.__doc__ = target.__doc__.format(**kwargs)
+        return target
+
+    return decorator


### PR DESCRIPTION
Solution:
- add api in pystarport to generate module account addresses

usage:
```
$ pystarport cli - module_address distribution
cro1jv65s3grqf6v6jl3dp4t6c9t9rk99cd8lyv94w
$ pystarport cli - balance `pystarport cli - module_address distribution`
529955
```

to see all the module account names:
```
$ pystarport cli - module_address --help
...
    NAME
        name of module account, values: fee_collector,mint,gov,distribution,bonded_tokens_pool,not_bonded_tokens_pool