### PR TITLE
Problem: (fix #196) current goreleaser config may build binaries without ledger support

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -8,17 +8,17 @@ on:
       - "v*.*.*"
 jobs:
   goreleaser:
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.15.2
-      - uses: actions/checkout@v2
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
-        with:
-          version: latest
-          args: release --rm-dist
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
+      - name: release dry run
+        run: make release-dry-run
+      - name: setup release environment
+        run: |-
+          echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' > .release-env
+      - name: release publish
+        run: make release

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # Build
 build
+dist
 
 # Testing
 /coverage.*.txt

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,17 +3,49 @@ before:
   - go mod download
 
 builds:
-  - main: ./cmd/chain-maind
-    id: "chain-maind"
+  - id: "chain-maind-darwin"
+    main: ./cmd/chain-maind
     binary: chain-maind
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    flags:
+        - -tags=cgo,ledger,!test_ledger_mock,!ledger_mock,!ledger_zemu
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=crypto-com-chain -X github.com/cosmos/cosmos-sdk/version.ServerName=chain-maind -X github.com/cosmos/cosmos-sdk/version.ClientName=chain-maincli -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "chain-maind-linux"
+    main: ./cmd/chain-maind
+    binary: chain-maind
+    env:
+      - CGO_ENABLED=1
+      - CC=gcc
+      - CXX=g++
     goos:
       - linux
-      - darwin
+    goarch:
+      - amd64
+    flags:
+      - -tags=cgo,ledger,!test_ledger_mock,!ledger_mock,!ledger_zemu
+    ldflags:
+      - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=crypto-com-chain -X github.com/cosmos/cosmos-sdk/version.ServerName=chain-maind -X github.com/cosmos/cosmos-sdk/version.ClientName=chain-maincli -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
+  - id: "chain-maind-windows"
+    main: ./cmd/chain-maind
+    binary: chain-maind
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+      - CXX=x86_64-w64-mingw32-g++
+    goos:
       - windows
     goarch:
       - amd64
+    flags:
+      - -tags=cgo,ledger,!test_ledger_mock,!ledger_mock,!ledger_zemu
     ldflags:
       - -s -w -X github.com/cosmos/cosmos-sdk/version.Name=crypto-com-chain -X github.com/cosmos/cosmos-sdk/version.ServerName=chain-maind -X github.com/cosmos/cosmos-sdk/version.ClientName=chain-maincli -X github.com/cosmos/cosmos-sdk/version.Version={{.Version}} -X github.com/cosmos/cosmos-sdk/version.Commit={{.Commit}}
 
@@ -28,7 +60,9 @@ archives:
     - goos: windows
       format: zip
   builds:
-  - chain-maind
+  - chain-maind-darwin
+  - chain-maind-windows
+  - chain-maind-linux
 checksum:
   name_template: 'checksums.txt'
 changelog:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 PACKAGES=$(shell go list ./... | grep -v '/simulation')
+PACKAGE_NAME:=github.com/crypto-com/chain-main
+GOLANG_CROSS_VERSION  = v1.15.3
+
 
 VERSION := $(shell echo $(shell git describe --tags 2>/dev/null ) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
@@ -176,3 +179,33 @@ else
 	rm -rf nix-remote-builder
 endif
 endif
+
+.PHONY: release-dry-run
+release-dry-run:
+	docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-v ${GOPATH}/pkg:/go/pkg \
+		-w /go/src/$(PACKAGE_NAME) \
+		troian/golang-cross:${GOLANG_CROSS_VERSION} \
+		--rm-dist --skip-validate --skip-publish
+
+.PHONY: release
+release:
+	@if [ ! -f ".release-env" ]; then \
+		echo "\033[91m.release-env is required for release\033[0m";\
+		exit 1;\
+	fi
+	docker run \
+		--rm \
+		--privileged \
+		-e CGO_ENABLED=1 \
+		--env-file .release-env \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		troian/golang-cross:${GOLANG_CROSS_VERSION} \
+		release --rm-dist --skip-validate


### PR DESCRIPTION
solution: use docker to cross-compile the binary with `cgo` enabled