### PR TITLE
Problem: (fix #135) hw wallet not tested on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ dist
 /coverage.*.txt
 /data
 __pycache__
+*.pyc
 
 # Others
 frontend/node_modules


### PR DESCRIPTION
* test ledger device manually on windows with the binary build by the goreleaser , it works fine.
* integration test can not run on windows for the following reason:
    * nix does not support the windows platform
    * supervisor does not work fine on windows in my test
* Currently, [WSL does not have USB pass-through access](https://github.com/microsoft/WSL/issues/5158), so can't use ledger device on WSL.
* integration test works fine on windows WSL 2, if get an error like `docker-credential-desktop.exe not installed or not available in PATH`,  see [here](https://github.com/docker/for-mac/issues/3785)
* can not expose the container's port outside using the host network mode on WSL 2, so change to container link mode.
