### PR TITLE
Problem: goreleaser is using wrong Env for GitHub token (fixes #251)

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,7 +18,9 @@ jobs:
       - name: release dry run
         run: make release-dry-run
       - name: setup release environment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
-          echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' > .release-env
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
       - name: release publish
         run: make release

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,12 +74,12 @@ changelog:
 snapshot:
   name_template: "{{ .Tag }}-next"
 
-brews:
-  - name: "chain-maind"
-    description: "chain-main daemon"
-    homepage: "https://github.com/crypto-com/chain-main"
-    github:
-      owner: "crypto-com"
-      name: "homebrew-chain-maind"
-    install: |
-      bin.install "chain-maind"
+# brews:
+#   - name: "chain-maind"
+#     description: "chain-main daemon"
+#     homepage: "https://github.com/crypto-com/chain-main"
+#     github:
+#       owner: "crypto-com"
+#       name: "homebrew-chain-maind"
+#     install: |
+#       bin.install "chain-maind"


### PR DESCRIPTION
Solution: updated to use github token + commented out brews, as it may need to be updated manually
before permissioning is figured out
