### PR TITLE
Problem: (fix#290) community chat should point to discord instead of gitter going forward

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in contributing to Chain! Good places to start are this document and [the official documentation](https://github.com/crypto-com/chain-docs). If you have any questions, feel free to ask on [Gitter](https://gitter.im/crypto-com/community?utm_source=share-link&utm_medium=link&utm_campaign=share-link).
+Thank you for your interest in contributing to Chain! Good places to start are this document and [the official documentation](https://github.com/crypto-com/chain-docs). If you have any questions, feel free to ask on [Discord](https://discord.gg/pahqHz26q4).
 
 
 ## Code of Conduct

--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,8 @@
 <p align="center">
   <a href="https://github.com/crypto-com/chain-main/workflows"><img label="Build Status" src="https://github.com/crypto-com/chain-main/workflows/Build/badge.svg" /></a>
   <a href="https://codecov.io/gh/crypto-com/chain-main"><img label="Code Coverage" src="https://codecov.io/gh/crypto-com/chain-main/branch/master/graph/badge.svg" /></a>
-  <a href="https://gitter.im/crypto-com/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge"><img label="Gitter" src="https://badges.gitter.im/crypto-com/community.svg" /></a>
+  <a href="https://discord.gg/pahqHz26q4"><img label="Discord" src="https://img.shields.io/discord/783264383978569728.svg?color=7289da&label=Crypto.com-Chain&logo=discord&style=flat-square" /></a>
 </p>
-
 
 ## Table of Contents
 
@@ -34,6 +33,7 @@ intended as a backbone for some of the existing and future Crypto.com ecosystem.
 <a id="contributing" />
 
 ## 2. Contributing
+
 Please abide by the [Code of Conduct](CODE_OF_CONDUCT.md) in all interactions,
 and the [contributing guidelines](CONTRIBUTING.md) when submitting code.
 
@@ -56,9 +56,11 @@ Technical documentation can be found in this [Github repository](https://github.
 ```bash
 make build
 ```
+
 By default, the command will build a binary with Mainnet configurations.
 
 To build with different network, provided `NETWORK` variable to `make` command
+
 ```bash
 NETWORK=testnet make build
 ```
@@ -66,6 +68,7 @@ NETWORK=testnet make build
 <a id="nix" />
 
 #### 1. Nix
+
 Nix is a (cross-language) package manager for reproducible builds.
 On Linux and macOS, you can [install it as follows](https://nixos.org/download.html) (on Windows 10, you can possibly use the Windows Subsystem for Linux):
 
@@ -87,16 +90,19 @@ Optionally, you can also use a binary cache to speed up the build process:
 $ nix-env -iA cachix -f https://cachix.org/api/v1/install
 $ cachix use crypto-com
 ```
-<a id="start-local-full-node" />
-## 6. Start a Local Full Node
 
-TODO
+<a id="start-local-full-node" />
+
+## 6. Start a local Development Network and Node
+
+
+Please follow this [documentation](https://chain.crypto.com/docs/getting-started/local-devnet.html#devnet-running-latest-development-node) to run a local devnet.
 
 <a id="send-first-transaction" />
 
 ## 7. Send Your First Transaction
 
-TODO
+After setting the local devnet, you may interact with the your local blockchain by following this [documentation](https://chain.crypto.com/docs/getting-started/local-devnet.html#interact-with-the-chain). 
 
 <a id="testing" />
 
@@ -117,7 +123,8 @@ There are different tests that can be executed in the following ways:
 - [Project Website](http://chain.crypto.com/)
 - [Technical Documentation](http://chain.crypto.com/)
 - Community chatrooms (non-technical): [Discord](https://discord.gg/nsp9JTC) [Telegram](https://t.me/CryptoComOfficial)
-- Developer community chatroom (technical): [![Gitter](https://badges.gitter.im/crypto-com/community.svg)](https://gitter.im/crypto-com/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+- Developer community channel (technical): [![Support Server](https://img.shields.io/discord/783264383978569728.svg?color=7289da&label=Crypto.com-Chain&logo=discord&style=flat-square)](https://discord.gg/pahqHz26q4)
+
 - [Cosmos SDK documentation](https://docs.cosmos.network)
 - [Cosmos Discord](https://discord.gg/W8trcGV)
-- [pystarport](./pystarport/README.md)
+- [Pystarport](./pystarport/README.md)


### PR DESCRIPTION
Solution: 
- Redirected to the discord channel; 
- Updated the discord badge ![disc](https://user-images.githubusercontent.com/51898510/102072915-79a95600-3e3d-11eb-9d16-b3f716733e9c.png)
- Added descriptions to "6. Start a local Development Network and Node" and " 7. Send Your First Transaction"  .
