### PR TITLE
Problem: upgrade test failed after migrated to cosmos-sdk rc5

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -99,12 +99,18 @@ rec {
   ];
 
   # sources for integration tests
-  tests_src = lib.sourceByRegex ./. [
+  # it needs the chain source code to build patched binaries on the fly
+  tests_src = lib.sourceByRegex ./. ([
     "^integration_tests$"
     "^integration_tests/.*\\.py$"
     "^integration_tests/configs$"
     "^integration_tests/configs/.*"
-  ];
+    "^integration_tests/upgrade-test.nix$"
+    "^integration_tests/upgrade-test.patch$"
+    "^nix$"
+    "^nix/.*"
+    "^default.nix$"
+  ] ++ src_regexes);
 
   # an env which can run integration tests
   ci-env = pkgs.buildEnv {

--- a/integration_tests/test_gov.py
+++ b/integration_tests/test_gov.py
@@ -76,7 +76,9 @@ def test_param_proposal(cluster, vote_option):
             "no_with_veto": "0",
         }
 
-    wait_for_block_time(cluster, isoparse(proposal["voting_end_time"]))
+    wait_for_block_time(
+        cluster, isoparse(proposal["voting_end_time"]) + timedelta(seconds=5)
+    )
 
     proposal = cluster.query_proposal(proposal_id)
     if vote_option == "yes":

--- a/integration_tests/test_upgrade.py
+++ b/integration_tests/test_upgrade.py
@@ -78,9 +78,6 @@ def cosmovisor_cluster(pytestconfig, tmp_path_factory):
 
 
 @pytest.mark.slow
-@pytest.mark.skip(
-    reason="FIXME: needs more work / possible incompatible external components with rc5"
-)
 def test_cosmovisor(cosmovisor_cluster):
     """
     - propose an upgrade and pass it
@@ -121,7 +118,7 @@ def test_cosmovisor(cosmovisor_cluster):
     assert proposal["status"] == "PROPOSAL_STATUS_PASSED", proposal
 
     # block should just pass the target height
-    wait_for_block(cluster, target_height + 2)
+    wait_for_block(cluster, target_height + 2, timeout=120)
 
 
 def propose_and_pass(cluster, kind, proposal):
@@ -156,9 +153,6 @@ def propose_and_pass(cluster, kind, proposal):
 
 
 @pytest.mark.slow
-@pytest.mark.skip(
-    reason="FIXME: needs more work / possible incompatible external components with rc5"
-)
 def test_manual_upgrade(cosmovisor_cluster):
     """
     - do the upgrade test by replacing binary manually

--- a/integration_tests/upgrade-test.nix
+++ b/integration_tests/upgrade-test.nix
@@ -1,12 +1,7 @@
 let
   pkgs = import ../nix { };
   genesis = (import ../. { inherit pkgs; }).chain-maind-zemu;
-  # pin to a revision to avoid unnessesary rebuild
-  pinned = (import
-    (builtins.fetchTarball
-      "https://github.com/crypto-com/chain-main/archive/de34e77ef793b0e7975eb3596844245b61b4f652.tar.gz")
-    { inherit pkgs; ledger_zemu = true; });
-  upgrade-test = pinned.overrideAttrs (old: {
+  upgrade-test = genesis.overrideAttrs (old: {
     patches = [ ./upgrade-test.patch ];
   });
 in

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -19,8 +19,10 @@ def wait_for_block(cli, height, timeout=60):
         except AssertionError as e:
             print(f"get sync status failed: {e}", file=sys.stderr)
         else:
-            if int(status["SyncInfo"]["latest_block_height"]) >= height:
+            current_height = int(status["SyncInfo"]["latest_block_height"])
+            if current_height >= height:
                 break
+            print("current block height", current_height)
         time.sleep(0.5)
     else:
         raise TimeoutError(f"wait for block {height} timeout")


### PR DESCRIPTION
Reason: the binary built for upgrade integration tests is pinned to an
old version

Solution:
- build current source code


# PR Checklist:

- [x] Have you read the [CONTRIBUTING.md](https://github.com/crypto-com/chain-main/blob/master/CONTRIBUTING.md)?
- [x] Does your PR follow the [C4 patch requirements](https://rfc.zeromq.org/spec:42/C4/#23-patch-requirements)?
- [x] Have you rebased your work on top of the latest master? 
- [ ] Have you checked your code compiles? (`make`)
- [ ] Have you included tests for any non-trivial functionality?
- [ ] Have you checked your code passes the unit tests? (`make test`)
- [ ] Have you checked your code formatting is correct? (`go fmt`)
- [ ] Have you checked your basic code style is fine? (`golangci-lint run`)
- [ ] If you added any dependencies, have you checked they do not contain any known vulnerabilities? (`go list -json -m all | nancy sleuth`)
- [ ] If your changes affect the client infrastructure, have you run the integration test?
- [ ] If your changes affect public APIs, does your PR follow the [C4 evolution of public contracts](https://rfc.zeromq.org/spec:42/C4/#26-evolution-of-public-contracts)?
- [ ] If your code changes public APIs, have you incremented the crate version numbers and documented your changes in the [CHANGELOG.md](https://github.com/crypto-com/chain-main/blob/master/CHANGELOG.md)?
- [ ] If you are contributing for the first time, please read the agreement in [CONTRIBUTING.md](https://github.com/crypto-com/chain-main/blob/master/CONTRIBUTING.md) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://github.com/crypto-com/chain-main/blob/master/CONTRIBUTING.md#developer-certificate-of-originn).

Thank you for your code, it's appreciated! :)

