### PR TITLE
Problem: upgrade for crossfire was not correct

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -430,7 +430,7 @@ func New(
 	app.ScopedTransferKeeper = scopedTransferKeeper
 
 	// TODO: remove later?
-	app.UpgradeKeeper.SetUpgradeHandler("sdk-v0.41-upgrade", func(_ sdk.Context, _ upgradetypes.Plan) {})
+	app.UpgradeKeeper.SetUpgradeHandler("Crossfire_v0.9.0_Upgrade", func(_ sdk.Context, _ upgradetypes.Plan) {})
 
 	return app
 }

--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,7 @@ let
       src = lib.sourceByRegex ./. src_regexes;
     };
     subPackages = [ "cmd/chain-maind" ];
-    vendorSha256 = sha256:1kysv6rzraxihxb7xfbh63ds6m988x50wq4dg07pw08ig481hyxx;
+    vendorSha256 = sha256:0rrljrdhwq4rfx3ggmdck5i3xwxgzjbbf1i7rvnwwcxcqm9nnsxa;
     runVend = true;
     outputs = [
       "out"

--- a/go.mod
+++ b/go.mod
@@ -28,3 +28,5 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
 replace github.com/cosmos/ledger-cosmos-go => github.com/crypto-com/ledger-cosmos-go v0.9.10-0.20200929055312-01e1d341de0f
+
+replace github.com/cosmos/cosmos-sdk => github.com/crypto-com/cosmos-sdk v0.41.0-patched

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/coreos/go-systemd v0.0.0-20180511133405-39ca1b05acc7/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/cosmos/cosmos-sdk v0.41.0 h1:U614TXkI/+T8HY6V9krC0/mKaDm6qSs9EMFSIKuomCo=
-github.com/cosmos/cosmos-sdk v0.41.0/go.mod h1:vlgqdPpUGSxgqSbZea6fjszoLkPKwCuiqSBySLlv4ro=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d h1:49RLWk1j44Xu4fjHb6JFYmeUnDORVwHNkDxaQ0ctCVU=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
@@ -119,6 +117,8 @@ github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwc
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
+github.com/crypto-com/cosmos-sdk v0.41.0-patched h1:PH0z57ZcL+RcnmuHtfxNnNXc+fZjobdYvTGNRltO97Q=
+github.com/crypto-com/cosmos-sdk v0.41.0-patched/go.mod h1:vlgqdPpUGSxgqSbZea6fjszoLkPKwCuiqSBySLlv4ro=
 github.com/crypto-com/ledger-cosmos-go v0.9.10-0.20200929055312-01e1d341de0f h1:pizxWsDWb07eC9jhw1oEUraFSZr3q17jvBU8CZ5Cp6s=
 github.com/crypto-com/ledger-cosmos-go v0.9.10-0.20200929055312-01e1d341de0f/go.mod h1:TJ0bt9M3eOD5V6ZCUvenKA1ODkvOcYuJDMBr9/XW1QY=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,16 +1,16 @@
 {
     "cosmos-sdk": {
-        "branch": "release/v0.41.x",
+        "branch": "release/v0.41.x-patched",
         "description": ":chains: A Framework for Building High Value Public Blockchains :sparkles:",
         "homepage": "https://cosmos.network/",
-        "owner": "cosmos",
+        "owner": "crypto-com",
         "repo": "cosmos-sdk",
-        "rev": "f8a6987347611bb9c88065389613cbb0946ab609",
-        "sha256": "0jrki4a110hd5rhkhqrkqkhlsbf5kn4jpqdapl3ifjb19hvm2r1r",
+        "rev": "1dea5569bc98701c07680ac8883a0cf3843d66ef",
+        "sha256": "0kk5ygrdikqiix2pylxbpd5z6wwl570aq62avdxfy353g7w4gn3j",
         "type": "tarball",
-        "url": "https://github.com/cosmos/cosmos-sdk/archive/f8a6987347611bb9c88065389613cbb0946ab609.tar.gz",
+        "url": "https://github.com/crypto-com/cosmos-sdk/archive/1dea5569bc98701c07680ac8883a0cf3843d66ef.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "version": "v0.41.0"
+        "version": "v0.41.0-patched"
     },
     "nixpkgs": {
         "branch": "master",


### PR DESCRIPTION
Solution:
- updated the upgrade handler to what @lezzokafka put in the proposal
- updated SDK to a patched fork of v0.41 with the evidence / bech32 fix
